### PR TITLE
Image zoom and add more cover sizes (#74)

### DIFF
--- a/packages/frontend/app/config/consts/styles.ts
+++ b/packages/frontend/app/config/consts/styles.ts
@@ -27,6 +27,7 @@ export const PREVIEW_VARIABLE_NAMES = {
     display: '--cover-display',
     justifyContent: '--cover-justify-content',
     alignItems: '--cover-align-items',
-    flexDirection: '--cover-flex-direction'
+    flexDirection: '--cover-flex-direction',
+    zoom: '--cover-zoom'
   }
 } as const;

--- a/packages/frontend/app/features/landing/components/FeatureSizeInteractive.tsx
+++ b/packages/frontend/app/features/landing/components/FeatureSizeInteractive.tsx
@@ -17,6 +17,7 @@ export function FeatureSizeInteractive() {
       defaultImageSize={imageSize}
       onAspectRatioChange={(value) => onAspectRatioChange(value as DownloadSizeInfo | null)}
       width="100%"
+      size="sm"
     />
   );
 }

--- a/packages/frontend/app/features/preview/components/CoverImage.tsx
+++ b/packages/frontend/app/features/preview/components/CoverImage.tsx
@@ -12,8 +12,11 @@ import { updateCSSVariables, getAspectRatioData } from '~/shared/utils/styles';
 import { CoverImageControls } from '~/features/preview/components/CoverImageControls';
 import { CoverImageSize } from '~/shared/components/CoverImageSize';
 import { useEditorUIStore } from '~/shared/stores/EditorUIStore';
-import type { DownloadSizeInfo } from '~/shared/consts';
 import { Logo } from '~/shared/components/Logo';
+import { ZoomControl } from '~/features/preview/components/ZoomControl';
+
+import type { DownloadSizeInfo } from '~/shared/consts';
+
 const Confetti = lazy(() => import('~/features/preview/components/Confetti'));
 
 export function CoverImage({ imageNodeRef }: { imageNodeRef: React.RefObject<HTMLDivElement | null> }) {
@@ -88,6 +91,9 @@ export function CoverImage({ imageNodeRef }: { imageNodeRef: React.RefObject<HTM
         ) : null}
 
         <ImagePreview imageNodeRef={imageNodeRef} />
+        <Box visibleFrom="lg" pos="absolute" bottom={16} left={20}>
+          <ZoomControl />
+        </Box>
       </Box>
 
       {isSuccessModalOpen && <DownloadSuccessModal close={closeSuccessModal} />}

--- a/packages/frontend/app/features/preview/components/ImagePreview.tsx
+++ b/packages/frontend/app/features/preview/components/ImagePreview.tsx
@@ -32,7 +32,7 @@ export function ImagePreview({ imageNodeRef }: { imageNodeRef: React.RefObject<H
             alignItems: 'var(--cover-align-items)',
             position: 'relative',
             flexDirection: 'var(--cover-flex-direction)' as React.CSSProperties['flexDirection'],
-            maxWidth: '900px',
+            maxWidth: '800px',
             gap: '1rem',
             overflow: 'hidden',
             padding: '3rem',

--- a/packages/frontend/app/features/preview/components/ZoomControl.tsx
+++ b/packages/frontend/app/features/preview/components/ZoomControl.tsx
@@ -1,0 +1,36 @@
+import { ButtonGroup, Button } from '@mantine/core';
+import { ZoomIn, ZoomOut } from 'iconoir-react';
+import { useEditorUIStore, type ZoomStep } from '~/shared/stores/EditorUIStore';
+import { updateCSSVariables } from '~/shared/utils/styles';
+import { zoomMap, MAX_ZOOM_STEP, MIN_ZOOM_STEP } from '~/features/preview/consts';
+
+export function ZoomControl() {
+  const { zoomStep, setZoomStep } = useEditorUIStore();
+
+  const handleZoom = (direction: 'in' | 'out') => {
+    const currentZoom = zoomStep;
+    const newZoom = currentZoom + (direction === 'in' ? 1 : -1);
+
+    if (newZoom >= MIN_ZOOM_STEP && newZoom <= MAX_ZOOM_STEP) {
+      setZoomStep(newZoom as ZoomStep);
+      updateCSSVariables({
+        '--cover-zoom': `scale(${zoomMap[newZoom as keyof typeof zoomMap]})`
+      });
+    }
+  };
+
+  const isMaxZoom = zoomStep >= MAX_ZOOM_STEP;
+  const isMinZoom = zoomStep <= MIN_ZOOM_STEP;
+
+  return (
+    <ButtonGroup>
+      <Button aria-label="Zoom In" variant="default" onClick={() => handleZoom('in')} disabled={isMaxZoom}>
+        <ZoomIn />
+      </Button>
+
+      <Button aria-label="Zoom Out" variant="default" onClick={() => handleZoom('out')} disabled={isMinZoom}>
+        <ZoomOut />
+      </Button>
+    </ButtonGroup>
+  );
+}

--- a/packages/frontend/app/features/preview/consts/index.ts
+++ b/packages/frontend/app/features/preview/consts/index.ts
@@ -1,0 +1,12 @@
+export const zoomMap = {
+  '-3': 0.82,
+  '-2': 0.88,
+  '-1': 0.94,
+  0: 1,
+  1: 1.06,
+  2: 1.12,
+  3: 1.18
+};
+
+export const MAX_ZOOM_STEP = 3;
+export const MIN_ZOOM_STEP = -3;

--- a/packages/frontend/app/features/preview/styles/CoverImage.module.css
+++ b/packages/frontend/app/features/preview/styles/CoverImage.module.css
@@ -28,6 +28,8 @@
   --cover-secondary-right: unset;
   --cover-secondary-left: unset;
   --cover-secondary-position: relative;
+
+  --cover-zoom: scale(1);
 }
 
 .coverWrapper {
@@ -41,6 +43,7 @@
   text-align: center;
   gap: 1rem;
   padding: 1.5rem 1rem;
+  overflow: hidden;
   z-index: 2;
   margin: 0 auto;
   background-image: radial-gradient(var(--mantine-color-violet-2) 1px, transparent 1px);
@@ -65,20 +68,24 @@
 
 .coverSkeleton {
   display: block;
-  width: min(calc(90vw - 360px), 900px);
+  width: min(calc(90vw - 360px), 800px);
   margin: 0 auto;
   min-width: 320px;
   aspect-ratio: var(--cover-aspect-ratio);
   overflow: hidden;
   z-index: 99;
   padding: 2rem;
+  transform: scale(1);
 }
 
 .innerCover {
   width: 100%;
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
 
-  @media (min-width: em(992px)) {
-    width: min(calc(90vw - 360px), 900px);
+  @media (min-width: 992px) {
+    transform: var(--cover-zoom);
+    transform-origin: center center;
+    transition: transform 0.2s ease;
+    width: min(calc(90vw - 360px), 800px);
   }
 }

--- a/packages/frontend/app/shared/components/CoverImageSize.tsx
+++ b/packages/frontend/app/shared/components/CoverImageSize.tsx
@@ -6,19 +6,20 @@ export function CoverImageSize({
   defaultImageSize,
   onAspectRatioChange,
   width = '275px',
+  size = 'md',
   ...rest
 }: {
   defaultImageSize: string;
   onAspectRatioChange: (value: string | null) => void;
   label?: string;
   width?: string;
-
+  size?: 'sm' | 'md';
   rest?: SelectProps;
 }) {
   return (
     <Select
       w={width}
-      size="md"
+      size={size}
       maw={275}
       aria-label="Cover image size"
       value={defaultImageSize}
@@ -31,6 +32,7 @@ export function CoverImageSize({
       allowDeselect={false}
       comboboxProps={{ width: '300px', position: 'bottom' }}
       checkIconPosition="right"
+      maxDropdownHeight={500}
       {...rest}
     />
   );

--- a/packages/frontend/app/shared/consts/index.ts
+++ b/packages/frontend/app/shared/consts/index.ts
@@ -30,19 +30,19 @@ export type RGBAColor = `rgba(${number}, ${number}, ${number}, ${number})`;
 export type HEXColor = `#${string}`;
 
 export const IMAGE_DOWNLOAD_SIZES = {
-  hashnode: {
-    label: '(Hashnode)',
-    value: 'hashnode:1.9:1600x840',
-    width: 1600,
-    height: 840,
-    aspectRatio: 1.9
-  },
   devto: {
     label: '(Dev)',
     value: 'dev:2.38:1000x420',
     width: 1000,
     height: 420,
     aspectRatio: 2.38
+  },
+  hashnode: {
+    label: '(Hashnode)',
+    value: 'hashnode:1.9:1600x840',
+    width: 1600,
+    height: 840,
+    aspectRatio: 1.9
   },
   mediumRegular: {
     label: '(Medium)',
@@ -57,6 +57,20 @@ export const IMAGE_DOWNLOAD_SIZES = {
     width: 2500,
     height: 1250,
     aspectRatio: 2
+  },
+  custom1: {
+    label: '',
+    value: 'custom1:1.9:1200x630',
+    width: 1200,
+    height: 630,
+    aspectRatio: 1.9
+  },
+  custom2: {
+    label: '',
+    value: 'custom2:1.33:1200x900',
+    width: 1200,
+    height: 900,
+    aspectRatio: 1.33
   }
 } as const;
 

--- a/packages/frontend/app/shared/stores/EditorUIStore.tsx
+++ b/packages/frontend/app/shared/stores/EditorUIStore.tsx
@@ -1,13 +1,18 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { DeepReadonly } from '~/shared/types';
+import { updateCSSVariables } from '~/shared/utils/styles';
+import { zoomMap } from '~/features/preview/consts';
+
 export type OpenSection = 'templates' | 'text' | 'background' | 'info';
+export type ZoomStep = -3 | -2 | -1 | 0 | 1 | 2 | 3;
 
 type EditorUIState = DeepReadonly<{
   isDrawerOpen: boolean;
   openSection: OpenSection;
   hasSeenWelcome: boolean;
   isHydrated: boolean;
+  zoomStep: ZoomStep;
 }>;
 
 type EditorUIActions = {
@@ -15,6 +20,7 @@ type EditorUIActions = {
   setHasHydrated: (isHydrated: boolean) => void;
   setOpenSection: (section: OpenSection) => void;
   setHasSeenWelcome: (hasSeen: boolean) => void;
+  setZoomStep: (step: ZoomStep) => void;
 };
 
 export const useEditorUIStore = create<EditorUIState & EditorUIActions>()(
@@ -24,11 +30,12 @@ export const useEditorUIStore = create<EditorUIState & EditorUIActions>()(
       openSection: 'templates',
       hasSeenWelcome: false,
       isHydrated: false,
-
+      zoomStep: 0,
       setDrawerOpen: (isOpen: boolean) => set({ isDrawerOpen: isOpen }),
       setHasHydrated: (isHydrated: boolean) => set({ isHydrated: isHydrated }),
       setOpenSection: (section: OpenSection) => set({ openSection: section }),
-      setHasSeenWelcome: (hasSeen: boolean) => set({ hasSeenWelcome: hasSeen })
+      setHasSeenWelcome: (hasSeen: boolean) => set({ hasSeenWelcome: hasSeen }),
+      setZoomStep: (step: ZoomStep) => set({ zoomStep: step })
     }),
     {
       name: 'editor-ui-storage',
@@ -36,11 +43,18 @@ export const useEditorUIStore = create<EditorUIState & EditorUIActions>()(
       partialize: (state) => ({
         isDrawerOpen: state.isDrawerOpen,
         openSection: state.openSection,
-        hasSeenWelcome: state.hasSeenWelcome
+        hasSeenWelcome: state.hasSeenWelcome,
+        zoomStep: state.zoomStep
       }),
       version: 1.1,
       onRehydrateStorage: () => (state) => {
         state?.setHasHydrated(true);
+
+        if (state?.zoomStep) {
+          updateCSSVariables({
+            '--cover-zoom': `scale(${zoomMap[state.zoomStep as keyof typeof zoomMap]})`
+          });
+        }
       }
     }
   )

--- a/packages/frontend/app/shared/utils/styles.ts
+++ b/packages/frontend/app/shared/utils/styles.ts
@@ -11,6 +11,7 @@ export const updateCSSVariables = (variables: Partial<Record<CSSVariableKey, str
 export const getAspectRatioData = (value: DownloadSizeInfo) => {
   const [id, aspectRatio, size] = value.split(':');
   const [width, height] = size.split('x');
+
   return {
     id,
     aspectRatio: Number(aspectRatio),


### PR DESCRIPTION
* Update README.md

* feat: add basic zoom feature to cover preview desktop + 2 new image sizes

* fix: zoom steps should be equal